### PR TITLE
Clean up transferred files.

### DIFF
--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -5,13 +5,6 @@
     <title>{{ title }}</title>
     <link rel="stylesheet" type="text/css" href="../static/css/styles.css">
     <link rel="stylesheet" type="text/css" href="../static/css/normalize/normalize.css">
-    <style>
-        .demo-container {
-            padding: 2%;
-            margin: 2%;
-            border: solid 5px black;
-        }
-    </style>
     {% block head %}
     {% endblock %}
 </head>

--- a/templates/current-semester-comms-interior.html.j2
+++ b/templates/current-semester-comms-interior.html.j2
@@ -1,11 +1,5 @@
 {% extends "base.html.j2" %}
 {% block content %}
-<h1>COMMS SPECIFIC INTERNAL BOX MOCKUP</h1>
-<p>Read comments in the source code for more notes</p>
-
-<div class="demo-container">
-
-    <!-- Everything below this section will be part of the final code-->
     <main>
         <div class="points-bar">
             <div class="chart-bar"> <!--Flexbox-->
@@ -99,8 +93,4 @@
             </section>
         </div>
     </main>
-
-    <!-- Everything above this section will be part of the final code-->
-
-</div>
 {% endblock %}

--- a/templates/current-semester-wic-history-interior.html.j2
+++ b/templates/current-semester-wic-history-interior.html.j2
@@ -1,13 +1,6 @@
 {% extends "base.html.j2" %}
 {% block content %}
 
-<h1>WIC SPECIFIC HISTORY INTERNAL BOX MOCKUP</h1>
-<p>Read comments in the source code for more notes</p>
-
-<div class="demo-container">
-
-<!-- Everything below this section will be part of the final code-->
-
 <main class="table-container membership-history-container">
     <div>
         <div>
@@ -103,7 +96,4 @@
     </div>
 </main>
 
-<!-- Everything above this section will be part of the final code-->
-
-</div>
 {% endblock %}

--- a/templates/current-semester-wics.html.j2
+++ b/templates/current-semester-wics.html.j2
@@ -1,7 +1,7 @@
 {% extends "base.html.j2" %}
 {% block content %}
 
-    <main>
+<main>
 
     <div class="titletabssection">
         <h2>Women in Computing</h2>

--- a/templates/current-semester-wics.html.j2
+++ b/templates/current-semester-wics.html.j2
@@ -1,8 +1,5 @@
 {% extends "base.html.j2" %}
 {% block content %}
-<div class="demo-container">
-
-<!-- Everything below this section will be part of the final code-->
 
     <main>
 
@@ -135,8 +132,5 @@
 
 </main>
 
-<!-- Everything above this section will be part of the final code-->
-
-</div>
 
 {% endblock content %}


### PR DESCRIPTION
This commit removes the "demo-container" CSS class and all extra HTML used for mockup purposes. In other words, this removes headers such as "COMMS SPECIFIC INTERNAL BOX MOCKUP" and removes the black box that appears outside the main elements on several of the files. 